### PR TITLE
pass agentOptions to underlying request options

### DIFF
--- a/lib/bagofrequest.js
+++ b/lib/bagofrequest.js
@@ -46,6 +46,10 @@ function req(method, url, opts, cb) {
     }
   }
 
+  if(opts.agentOptions){
+    params.agentOptions = opts.agentOptions;
+  }
+
   // just a more readable opt name for query strings
   if (opts.queryStrings) {
     params.qs = opts.queryStrings;

--- a/lib/bagofrequest.js
+++ b/lib/bagofrequest.js
@@ -46,17 +46,13 @@ function req(method, url, opts, cb) {
     }
   }
 
-  if(opts.agentOptions){
-    params.agentOptions = opts.agentOptions;
-  }
-
   // just a more readable opt name for query strings
   if (opts.queryStrings) {
     params.qs = opts.queryStrings;
   }
 
   // headers and payload handling
-  ['headers', 'body', 'form', 'json', 'multipart'].forEach(function (opt) {
+  ['headers', 'body', 'form', 'json', 'multipart','agentOptions'].forEach(function (opt) {
     if (opts[opt]) {
       params[opt] = opts[opt];
     }

--- a/test/bagofrequest.js
+++ b/test/bagofrequest.js
@@ -8,6 +8,20 @@ buster.testCase('http - request', {
   setUp: function () {
     this.mock({});
   },
+  'should pass agentOptions to underlying request': function  (done) {
+    this.stub(request, 'post', function (params, cb) {
+      assert.equals(params.headers.foo, 'bar');
+      assert.equals(params.agentOptions.passphrase, 'a123');
+      cb(null, { statusCode: 200 });
+    });
+    function _success(result, cb) {
+      cb(null, result);
+    }
+    bag.request('POST', 'http://someurl', { headers: { foo: 'bar' },agentOptions: { passphrase: 'a123'}, handlers: { 200: _success }}, function (err, result) {
+      assert.isNull(err);
+      done();
+    });
+  },
   'should pass error to callback when there is an error while sending request': function (done) {
     this.stub(process, 'env', {});
     this.stub(request, 'get', function (params, cb) {


### PR DESCRIPTION
Hi,

in order to use client side SSL authentication with nestor, I made a small fix to bagofrequest to pass agentOptions to the underlying request instance. See https://github.com/request/request#tlsssl-protocol

Regards,
Ben
PS: I have a working prototype of nestor with client side ssl authentication. That need's some cleanup and I make a pull request for that as well.
